### PR TITLE
chore: suggest `iris-png` name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "iris"
+name = "iris-png"
 authors = ["Matthew Kim"]
 version = "0.1.1"
 edition = "2021"


### PR DESCRIPTION
Hi @friendlymatthew 

I have created a pull request that updates the name of your crate to `iris-png`. I believe this is accurate since your crate works specifically with PNGs. If you have another suggestion, I have allowed edits by maintainers for this PR. Anything but `iris` works.

I understand that you contacted that crates.io team to take ownership of the crate `iris` under the name squatting policies. However, I was not in violation of these policies, and sooner or later, the team will overturn this decision and return the crate to it's rightful owner.

Apart from the organization, repository, and website which I registered under the name "iris," I also registered a company along with a trademark a few weeks ago. I will be using it against you if the crate is not peacefully returned.

